### PR TITLE
メンバーセクションのsp対応

### DIFF
--- a/components/pages/Index/Member.vue
+++ b/components/pages/Index/Member.vue
@@ -83,13 +83,9 @@
       display: flex;
       flex-wrap: wrap;
       justify-content: space-between;
-      margin: 0 20px;
-      @include desktop() {
-        margin: 0;
-      }
     }
     &__listItem{
-      width: 40%;
+      width: 48%;
       text-align: center;
       @include desktop() {
         width: 20%;

--- a/components/pages/Index/Member.vue
+++ b/components/pages/Index/Member.vue
@@ -31,6 +31,18 @@
           <p class="p-member__listItemName">岡山 海恵</p>
           <div class="p-member__listItemNameEn">Okayama Kaie</div>
         </div>
+        <div class="p-member__listItem">
+          <div class="p-member__listItemThumb"></div>
+          <div class="p-member__listItemPosition">アルバイト</div>
+          <p class="p-member__listItemName">飛田 一貴</p>
+          <div class="p-member__listItemNameEn">Tobita Kazuki</div>
+        </div>
+        <div class="p-member__listItem">
+          <div class="p-member__listItemThumb"></div>
+          <div class="p-member__listItemPosition">アルバイト</div>
+          <p class="p-member__listItemName">高橋 秀明</p>
+          <div class="p-member__listItemNameEn">Takahashi Hideaki</div>
+        </div>
       </div>
     </div>
   </section>
@@ -71,10 +83,17 @@
       display: flex;
       flex-wrap: wrap;
       justify-content: space-between;
+      margin: 0 20px;
+      @include desktop() {
+        margin: 0;
+      }
     }
     &__listItem{
-      width: 20%;
+      width: 40%;
       text-align: center;
+      @include desktop() {
+        width: 20%;
+      }
     }
     &__listItemThumb{
       margin-bottom: 10px;


### PR DESCRIPTION
sp対応の時に```justify-content: space-around;```の方が見やすかったけれど、メンバーが奇数になった場合1人だけ中央寄せになるため```margin: 0 20px;```をつけて少し真ん中よりにしました。
(pcの場合は```margin: 0;```)