### PR TITLE
[SP]「スキルアップ施策」項目のテキスト周りの調整

### DIFF
--- a/components/pages/Index/SkillUp.vue
+++ b/components/pages/Index/SkillUp.vue
@@ -59,7 +59,7 @@
     }
     &__headingIntro {
       margin-bottom: 40px;
-
+      line-height: 2;
     }
     &__Lists {
     }

--- a/components/pages/Index/_SkillUpList.vue
+++ b/components/pages/Index/_SkillUpList.vue
@@ -56,10 +56,13 @@
     &__ListItemDetail {
       display: inline-block;
       width: 60%;
-      padding: 40px;
+      padding: 20px;
       box-sizing: border-box;
       vertical-align: top;
-
+      line-height: 2;
+      @include desktop {
+        padding: 40px;
+      }
     }
     &__ListItemDetailHeading {
       font-weight: bold;


### PR DESCRIPTION
fixed #38 

- paddingを小さくしました。
- ```line-height: 2;```を指定しました。
- 「スキルアップ施策」のタイトル下の「chatboxでは自分で決めた...」のところにも```line-height: 2;```を指定しました。